### PR TITLE
Prevents cursor being placed at start of file

### DIFF
--- a/lib/wrap-selection.coffee
+++ b/lib/wrap-selection.coffee
@@ -13,9 +13,15 @@ module.exports = WrapSelection =
   wrapWithText: ->
     editor = atom.workspace.getActiveTextEditor()
     selections = editor.getSelections()
+    i = 0
     for selection in selections
         if not selection.isEmpty()
           range = selection.getBufferRange()
           selection.destroy()
-          editor.addCursorAtBufferPosition(range.start)
+          if i == 0
+            editor.setCursorBufferPosition(range.start)
+          else
+            editor.addCursorAtBufferPosition(range.start)
+
           editor.addCursorAtBufferPosition(range.end)
+          i++


### PR DESCRIPTION
Fixes #4 by checking if this is the first selection to be wrapped and if it is moving the cursor from the start of the document to the beginning of the buffer. All additional selections should receive new cursors at the beginning of their buffers. The first one has to be moved since selection.destroy() seems to place the cursor at the beginning of the file.
